### PR TITLE
FRI-326 Use branch locked flag rather than metadata lock message.

### DIFF
--- a/app/components/edit/edit.js
+++ b/app/components/edit/edit.js
@@ -260,7 +260,7 @@ angular.module('singleConceptAuthoringApp.edit', [
 
     function redirectToConflicts() {
       terminologyServerService.getBranch(metadataService.getBranchRoot() + '/' + $scope.projectKey).then(function (response) {
-        if (!response.metadata || response.metadata && !response.metadata.lock) {
+        if (!response.locked) {
           $location.url('tasks/task/' + $scope.projectKey + '/' + $scope.taskKey + '/conflicts');
         }
         else {

--- a/app/components/home/home.js
+++ b/app/components/home/home.js
@@ -307,7 +307,7 @@ angular.module('singleConceptAuthoringApp.home', [
 
             // check for project lock before continuing
             terminologyServerService.getBranch(projectBranch).then(function (response) {
-                if (!response.metadata || response.metadata && !response.metadata.lock) {
+                if (!response.locked) {
                     scaService.getUiStateForTask(task.projectKey, task.key, 'edit-panel')
                         .then(function (uiState) {
                             if (!uiState || Object.getOwnPropertyNames(uiState).length === 0) {
@@ -340,7 +340,7 @@ angular.module('singleConceptAuthoringApp.home', [
         function redirectToConflicts(branchRoot, projectKey, taskKey) {
           // check for branch lock before continuing
           terminologyServerService.getBranch(branchRoot + '/' + projectKey).then(function (response) {
-            if (!response.metadata || response.metadata && !response.metadata.lock) {
+            if (!response.locked) {
               $location.url('tasks/task/' + projectKey + '/' + taskKey + '/conflicts');
             }
             else {

--- a/app/components/project/project.js
+++ b/app/components/project/project.js
@@ -362,7 +362,7 @@ angular.module('singleConceptAuthoringApp.project', [
       };
       $scope.mergeAndRebase = function (task) {
         terminologyServerService.getBranch($scope.branch).then(function (response) {
-          if (!response.metadata || response.metadata && !response.metadata.lock) {
+          if (!response.locked) {
             $location.url('projects/project/' + $routeParams.projectKey + '/conflicts');
           }
           else {
@@ -389,9 +389,9 @@ angular.module('singleConceptAuthoringApp.project', [
           // if response contains no flags, simply promote
           if (!warningsFound) {
             terminologyServerService.getBranch($scope.branch).then(function (response) {
-              if (!response.metadata || response.metadata && !response.metadata.lock) {
+              if (!response.locked) {
                 terminologyServerService.getBranch(metadataService.getBranchRoot()).then(function (response) {
-                  if (!response.metadata || response.metadata && !response.metadata.lock) {
+                  if (!response.locked) {
                     notificationService.sendMessage('Promoting project...');
                     scaService.promoteProject($routeParams.projectKey).then(function (response) {
                       if (response.status === 'CONFLICTS') {
@@ -447,9 +447,9 @@ angular.module('singleConceptAuthoringApp.project', [
             modalInstance.result.then(function (proceed) {
               if (proceed) {
                 terminologyServerService.getBranch($scope.branch).then(function (response) {
-                  if (!response.metadata || response.metadata && !response.metadata.lock) {
+                  if (!response.locked) {
                     terminologyServerService.getBranch(metadataService.getBranchRoot()).then(function (response) {
-                      if (!response.metadata || response.metadata && !response.metadata.lock) {
+                      if (!response.locked) {
                         notificationService.sendMessage('Promoting project...');
                         scaService.promoteProject($routeParams.projectKey).then(function (response) {
                           if (response.status === 'CONFLICTS') {

--- a/app/components/review-tasks/reviewTasks.js
+++ b/app/components/review-tasks/reviewTasks.js
@@ -267,11 +267,11 @@ angular.module('singleConceptAuthoringApp.reviewTasks', [
 
         // check for project lock
         terminologyServerService.getBranch(metadataService.getBranchRoot() + '/' + task.projectKey).then(function (response) {
-          if (!response.metadata || response.metadata && !response.metadata.lock) {
+          if (!response.locked) {
 
             // check for task lock
             terminologyServerService.getBranch(metadataService.getBranchRoot() + '/' + task.projectKey + '/' + task.key).then(function (response) {
-              if (!response.metadata || response.metadata && !response.metadata.lock) {
+              if (!response.locked) {
                 $location.url('tasks/task/' + task.projectKey + '/' + task.key + '/conflicts');
               }
               else {

--- a/app/shared/task-detail/taskDetail.js
+++ b/app/shared/task-detail/taskDetail.js
@@ -495,7 +495,7 @@ angular.module('singleConceptAuthoringApp.taskDetail', [])
         terminologyServerService.getBranch($scope.branch).then(function (response) {
 
           // if lock found, set rootscope variable and continue polling
-          if (response.metadata && response.metadata.lock) {            
+          if (response.locked) {            
             $rootScope.branchLocked = true;
             $timeout(function () {
               // Stop checking for lock if the task key not found
@@ -637,7 +637,7 @@ angular.module('singleConceptAuthoringApp.taskDetail', [])
 
       $scope.viewConflicts = function () {
         terminologyServerService.getBranch(metadataService.getBranchRoot() + '/' + $routeParams.projectKey).then(function (response) {
-          if (!response.metadata || response.metadata && !response.metadata.lock) {
+          if (!response.locked) {
             $location.url('tasks/task/' + $routeParams.projectKey + '/' + $routeParams.taskKey + '/conflicts');
           }
           else {


### PR DESCRIPTION
The metadata lock message stays there after a commit is reverted. The branch locked flag must be used instead to prevent the UI thinking a branch is still locked after a commit rollback.